### PR TITLE
fix: remove multiple callback invocation

### DIFF
--- a/android/src/main/java/com/rn/ecc/ECCModule.java
+++ b/android/src/main/java/com/rn/ecc/ECCModule.java
@@ -165,7 +165,6 @@ public class ECCModule extends ReactContextBaseJavaModule {
             function.invoke(ex.toString(), null);
             return;
         }
-        function.invoke(null, false);
     }
 
     public KeyStore.Entry getEntry (String publicKeyString) throws GeneralSecurityException, IOException {


### PR DESCRIPTION
Hi,
I was looking for simple EC implementation for react-native and I only found your projects, which was usable. It does what I need, unfortunately the function `hasKey` does not work on Android. I get the following error message:
`Illegal callback invocation from native module. This callback type only permits a single invocation from native code `.

I saw that `function.invoke` is called twice in the method and accordingly removed the last call. With this the function works as it should.